### PR TITLE
fix: harden serve task dev flag handling

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -19,8 +19,12 @@ and open [localhost:8000](http://localhost:8000) in your browser.
 Within the Dev Container this is equivalent to:
 
 ```sh
-poe serve
+poe serve{%- if with_fastapi_api %} --dev{%- endif %}
 ```
+{%- if with_fastapi_api %}
+
+Use `poe serve` without the `--dev` flag to run the production-ready server configuration.
+{%- endif %}
 
 ## Contributing
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -107,17 +107,17 @@ type = "simple"
   [tool.poe.tasks.serve]
   help = "Serve the REST API"
   shell = """
-    if [ $dev ]
-    then {
+    if [ "$dev" = "true" ] || [ "$dev" = "1" ]
+    then
       uvicorn \
-        --host $host \
-        --port $port \
+        --host "$host" \
+        --port "$port" \
         --reload \
         {{ project_name_snake_case }}.api:app
-    } else {
+    else
       gunicorn \
         --access-logfile - \
-        --bind $host:$port \
+        --bind "$host:$port" \
         --graceful-timeout 10 \
         --keep-alive 10 \
         --log-file - \
@@ -126,7 +126,7 @@ type = "simple"
         --worker-tmp-dir /dev/shm \
         --workers 2 \
         {{ project_name_snake_case }}.api:app
-    } fi
+    fi
     """
 
     [[tool.poe.tasks.serve.args]]


### PR DESCRIPTION
## Summary
- quote the `poe serve` dev flag and check for explicit true/1 values before reloading
- ensure host and port arguments are safely quoted so both uvicorn and gunicorn branches work
- document development versus production usage of the serve task in the README template

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906133258388329bd216e9edb7d9dab