### PR TITLE
Fix FastAPI lifespan logging handler cleanup

### DIFF
--- a/template/src/{{ project_name_snake_case }}/{% if with_fastapi_api %}api{% endif %}/main.py.jinja
+++ b/template/src/{{ project_name_snake_case }}/{% if with_fastapi_api %}api{% endif %}/main.py.jinja
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Handle FastAPI startup and shutdown events."""
     # Startup events.
-    for handler in logging.root.handlers:
+    for handler in list(logging.root.handlers):
         logging.root.removeHandler(handler)
     yield
     # Shutdown events.


### PR DESCRIPTION
## Summary
- ensure the FastAPI template clears logging handlers by iterating over a copy to avoid skipped handlers

## Testing
- python - <<'PY' (lifespan handler verification script)


------
https://chatgpt.com/codex/tasks/task_e_690613675ccc83299b27202916931c8e