### PR TITLE
feat: configure FastAPI scaffold metadata

### DIFF
--- a/template/src/{{ project_name_snake_case }}/{% if with_fastapi_api %}api{% endif %}/main.py.jinja
+++ b/template/src/{{ project_name_snake_case }}/{% if with_fastapi_api %}api{% endif %}/main.py.jinja
@@ -3,16 +3,11 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 from fastapi import FastAPI
 
 from {{ project_name_snake_case }}.api.basemodels import HealthResponse
-
-try:
-    API_VERSION = version("{{ project_name_kebab_case }}")
-except PackageNotFoundError:
-    API_VERSION = "0.0.0"
 
 
 @asynccontextmanager
@@ -27,9 +22,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
 
 app = FastAPI(
-    title="{{ project_name }} API",
-    description="{{ project_description }}",
-    version=API_VERSION,
+    title="{{ project_name | replace('"', '\\"') | replace('\n', '\\n') | replace('\r', '\\r') }} API",
+    description="{{ project_description | replace('"', '\\"') | replace('\n', '\\n') | replace('\r', '\\r') }}",
+    version=version("{{ project_name_kebab_case }}"),
     docs_url="/",
     lifespan=lifespan,
 )


### PR DESCRIPTION
## Summary
- configure the FastAPI scaffold to expose the interactive docs at the base URL
- populate the scaffolded app metadata with the project name and description provided via Copier
- escape user-provided strings to keep the generated FastAPI app valid when they contain quotes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691453dd4ad083258127a667e5a50803)