### PR TITLE
docs: add AGENTS guide template

### DIFF
--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -13,7 +13,7 @@ Key files and directories in the generated project include:
 - `.github/workflows/` contains the automation pipelines:
   - `test.yml` runs the lint and test matrix.
   - `summary.yml` aggregates workflow results into a PR summary comment (`main` <- `dev`).
-  - `pr.yml` executes static analysis on pull requests (`dev` <- `<feature-branch>`).
+  - `pr.yml` executes a Codex-backed analysis on pull requests (`dev` <- `<feature-branch>`).
   {%- if project_type == 'app' %}
   - `deploy.yml` publishes the application image.
   {%- endif %}


### PR DESCRIPTION
## Summary
- add an AGENTS.md.jinja scaffold that documents the default project structure and workflows

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914548d97588325b80ac0d533d47fd6)