### PR TITLE
Dependabot access

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: read
-      pull-requests: read
+      issues: write
+      pull-requests: write
     outputs:
       final_message: ${{ steps.run_codex.outputs['final-message'] }}
     steps:


### PR DESCRIPTION
This pull request updates the permissions for the GitHub Actions workflow in `.github/workflows/pr.yml`. The workflow now requests write access for both issues and pull requests, instead of just read access. This change will allow the workflow to make updates or comments on issues and pull requests as needed.

- Increased permissions for `issues` and `pull-requests` from `read` to `write` in the workflow configuration to enable the workflow to modify or comment on issues and pull requests.