### PR TITLE
Bump notebook versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Fetch PR conversation
         id: fetch_conversation
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ github.token }}
           result-encoding: string
@@ -86,7 +86,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Report Codex feedback
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: velta-forge-backend
 

--- a/template/.github/workflows/pr.yml
+++ b/template/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Fetch PR conversation
         id: fetch_conversation
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ github.token }}
           result-encoding: string
@@ -88,7 +88,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Report Codex feedback
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
         with:

--- a/template/.github/workflows/summary.yml
+++ b/template/.github/workflows/summary.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Fetch PR conversation
         id: fetch_conversation
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ github.token }}
           result-encoding: string
@@ -86,7 +86,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Report Codex feedback
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
         with:

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 23
 

--- a/template/.github/workflows/{% if project_type == 'app' %}deploy.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if project_type == 'app' %}deploy.yml{% endif %}.jinja
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the Docker registry
         uses: docker/login-action@v3

--- a/template/.github/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja
+++ b/template/.github/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use newer versions of their respective actions. The main focus is on upgrading the `actions/github-script`, `actions/checkout`, and `actions/setup-node` actions to improve compatibility, security, and performance across both main and template workflow files.

**Workflow action version upgrades:**

* Upgraded `actions/github-script` from `v7` to `v8` in `.github/workflows/pr.yml`, `template/.github/workflows/pr.yml`, and `template/.github/workflows/summary.yml` for both fetching PR conversations and reporting Codex feedback. [[1]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L28-R28) [[2]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L89-R89) [[3]](diffhunk://#diff-a5cf51819a439029a0d4afc3a269037e97a00e6ee70f56109e289b2b6b195150L30-R30) [[4]](diffhunk://#diff-a5cf51819a439029a0d4afc3a269037e97a00e6ee70f56109e289b2b6b195150L91-R91) [[5]](diffhunk://#diff-54d74325f42952a49208724228231dda761a4fd61157f293741a5ff7af818eaeL30-R30) [[6]](diffhunk://#diff-54d74325f42952a49208724228231dda761a4fd61157f293741a5ff7af818eaeL89-R89)
* Updated `actions/checkout` from `v4` to `v5` in `.github/workflows/test.yml`, `template/.github/workflows/test.yml`, `template/.github/workflows/{% if project_type == 'app' %}deploy.yml{% endif %}.jinja`, and `template/.github/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja`. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L23-R23) [[2]](diffhunk://#diff-a8bd85484948cd4e3c9c725c7160f7b8c3d952905d105bcc62d2107f01556a34L23-R26) [[3]](diffhunk://#diff-c2e2ff3866532321948830fe168df38a739dd14d383891f14e6bf45e57efb65dL33-R33) [[4]](diffhunk://#diff-749efe103a0e94898446240cb6c200973cf22e6ca8dd9c1bf20960deca10b047L17-R17)
* Upgraded `actions/setup-node` from `v4` to `v6` in `template/.github/workflows/test.yml` to use the latest Node.js setup action.