### PR TITLE
docs: relaunch changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
-## v1.0.0 (2025-11-01)
+# Changelog
 
-### Feat
+## v1.0.0 (2025-11-12)
 
-- add template health check endpoint (#7)
-- Init scaffolding
+### Highlights
+- Launched the Velta Forge Backend Copier template as the canonical starting point for new Velta services, bundling documentation and automation that reflect the Velta Way of Work.
 
-### Fix
+### Added
+- FastAPI-ready application skeleton with optional REST API module, `main.py` entrypoint, and pytest suite wiring to keep new services production-ready from day one.
+- Dev Container, Docker Compose, and Dockerfile assets so teams can develop inside a consistent Linux environment locally or in GitHub Codespaces.
+- uv-driven project configuration with Poe the Poet tasks for serving, linting, and testing, plus Ruff, pytest, coverage, and Commitizen integrations to enforce quality gates automatically.
+- GitHub Actions workflows, Dependabot automation, and reusable test scripts (`test.sh`, `test-build.sh`) to validate rendered projects and keep dependencies healthy.
+- Template-specific documentation (`README.md`, `AGENTS.md`, template changelog) that guides engineers and AI agents through the scaffold's conventions.
 
-- quote serve task dev flag (#4)
-- trailing backslash in CI test (#1)
+### Tooling & Maintenance
+- Copier configuration (`copier.yml`) and template assets under `template/` mirroring the repository guidance, ensuring freshly generated projects inherit the same structure, docs, and guardrails.


### PR DESCRIPTION
## Summary
- restart the changelog for the v1.0.0 release dated 2025-11-12
- document the template features, tooling, and automation included in the initial release

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914ba0896d88325ab1bf3d04c13fa94)